### PR TITLE
Set Pull Policy to Latest

### DIFF
--- a/Docker-Compose-Template/docker-compose-default.yml
+++ b/Docker-Compose-Template/docker-compose-default.yml
@@ -3,6 +3,7 @@ services:
   emulator:
     container_name: "servicebus-emulator"
     image: mcr.microsoft.com/azure-messaging/servicebus-emulator:latest
+    pull_policy: always
     volumes:
       - "${CONFIG_PATH}:/ServiceBus_Emulator/ConfigFiles/Config.json"
     ports:

--- a/Docker-Compose-Template/docker-compose-standalone-emulator.yml
+++ b/Docker-Compose-Template/docker-compose-standalone-emulator.yml
@@ -6,6 +6,7 @@ services:
   emulator:
     container_name: "servicebus-emulator"
     image: mcr.microsoft.com/azure-messaging/servicebus-emulator:latest
+    pull_policy: always
     volumes:
       - "${CONFIG_PATH}:/ServiceBus_Emulator/ConfigFiles/Config.json"
     ports:

--- a/Docker-Compose-Template/docker-compose-with-containerized-app.yml
+++ b/Docker-Compose-Template/docker-compose-with-containerized-app.yml
@@ -3,6 +3,7 @@ services:
   emulator:
     container_name: "servicebus-emulator"
     image: mcr.microsoft.com/azure-messaging/servicebus-emulator:latest
+    pull_policy: always
     volumes:
       - "./Config.json:/ServiceBus_Emulator/ConfigFiles/Config.json"
     ports:


### PR DESCRIPTION
In case local image is present in cache with same name+tag, currently on executing the script we will not be fetching the latest image from repository even if image present in the upstream repository has been updated.
This PR addresses the problem by setting the pull policy to "always".