### PR TITLE
.NET Console - Make use of existing connection string

### DIFF
--- a/Sample-Code-Snippets/NET/ServiceBus.Emulator.Console.Sample/ServiceBus.Emulator.Console.Sample/Program.cs
+++ b/Sample-Code-Snippets/NET/ServiceBus.Emulator.Console.Sample/ServiceBus.Emulator.Console.Sample/Program.cs
@@ -53,10 +53,9 @@ internal class Program
 
     public static async Task ConsumeMessageFromDefaultQueue()
     {
-        var connectionString = "Endpoint=sb://127.0.0.1;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;";
         string queueName = "queue.1";
 
-        var client = new ServiceBusClient(connectionString);
+        var client = new ServiceBusClient(_connectionString);
 
         ServiceBusReceiverOptions opt = new ServiceBusReceiverOptions
         {


### PR DESCRIPTION
A duplicate connection string is defined at the function level but exists as a class variable. 