### PR TITLE
Add configurable AMQP host port support

### DIFF
--- a/Docker-Compose-Template/docker-compose-default.yml
+++ b/Docker-Compose-Template/docker-compose-default.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - "${CONFIG_PATH:-../ServiceBus-Emulator/Config/Config.json}:/ServiceBus_Emulator/ConfigFiles/Config.json"
     ports:
-      - "5672:5672"
+      - "${EMULATOR_AMQP_PORT:-5672}:5672"
       - "5300:${EMULATOR_HTTP_PORT:-5300}"
     environment:
       SQL_SERVER: sqledge
@@ -34,4 +34,3 @@ services:
 
 networks:
   sb-emulator:
-

--- a/Docker-Compose-Template/docker-compose-standalone-emulator.yml
+++ b/Docker-Compose-Template/docker-compose-standalone-emulator.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - "${CONFIG_PATH:-../ServiceBus-Emulator/Config/Config.json}:/ServiceBus_Emulator/ConfigFiles/Config.json"
     ports:
-      - "5672:5672"
+      - "${EMULATOR_AMQP_PORT:-5672}:5672"
       - "5300:${EMULATOR_HTTP_PORT:-5300}"
     environment:
       SQL_SERVER: host.docker.internal:1433 # Host:Port for user speficied SQL DB container (Port is optional if default 1433 is used)

--- a/Docker-Compose-Template/docker-compose-with-containerized-app.yml
+++ b/Docker-Compose-Template/docker-compose-with-containerized-app.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - "${CONFIG_PATH:-../ServiceBus-Emulator/Config/Config.json}:/ServiceBus_Emulator/ConfigFiles/Config.json"
     ports:
-      - "5672:5672"
+      - "${EMULATOR_AMQP_PORT:-5672}:5672"
       - "5300:${EMULATOR_HTTP_PORT:-5300}"
     environment:
       SQL_SERVER: sqledge
@@ -146,4 +146,3 @@ services:
           - "java-sample-client-app"
 networks:
   sb-emulator:
-

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The Service Bus emulator uses a static connection string, but the host value var
 > By default, management operations using the Service Bus Administration Client require appending the **port number** to the emulator connection string.<br>
 > 
 > For example, when both the emulator and the application are running on the same machine, use the following connection string for administration operations:<br>
-> `"Endpoint=sb://localhost:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;";`
+> `Endpoint=sb://localhost:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;`
 > 
 > For management operations & health-check, the emulator uses port 5300 by default.<br>
 > You can configure the emulator to use a different port if required using the `EMULATOR_HTTP_PORT` environment variable.

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The Service Bus emulator uses a static connection string, but the host value var
 > By default, management operations using the Service Bus Administration Client require appending the **port number** to the emulator connection string.<br>
 > 
 > For example, when both the emulator and the application are running on the same machine, use the following connection string for administration operations:<br>
-> `Endpoint=sb://localhost:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;`
+`"Endpoint=sb://localhost:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;";`
 > 
 > For management operations & health-check, the emulator uses port 5300 by default.<br>
 > You can configure the emulator to use a different port if required using the `EMULATOR_HTTP_PORT` environment variable.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ After completing the prerequisites, you can proceed with the following steps to 
 
 1. Execute the setup script `LaunchEmulator.sh` . Running the script would  bring up two containers – Service Bus Emulator & Azure SQL Edge (dependency for Emulator)
 
+   Optionally, you can remap the host AMQP port (for example, to avoid conflicts with other local emulators):
+   ```shell
+   LaunchEmulator.sh --EMULATOR_AMQP_PORT=5674
+   ```
+
 
 2. Execute the same script `LaunchEmulator.sh` with the option `--compose-down=Y` to issue a `docker compose down` to terminate the containers.
 
@@ -155,10 +160,13 @@ The Service Bus emulator uses a static connection string, but the host value var
 
 > [!IMPORTANT]
 > 
+> Message send/receive operations use AMQP port **5672** by default.<br>
+> If you remap the host AMQP port (for example, `EMULATOR_AMQP_PORT=5674`), append that port in the connection string endpoint (for example, `Endpoint=sb://localhost:5674;...`).<br>
+> 
 > By default, management operations using the Service Bus Administration Client require appending the **port number** to the emulator connection string.<br>
 > 
 > For example, when both the emulator and the application are running on the same machine, use the following connection string for administration operations:<br>
-`"Endpoint=sb://localhost:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;";`
+> `"Endpoint=sb://localhost:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;";`
 > 
 > For management operations & health-check, the emulator uses port 5300 by default.<br>
 > You can configure the emulator to use a different port if required using the `EMULATOR_HTTP_PORT` environment variable.

--- a/ServiceBus-Emulator/Scripts/Common/LaunchEmulator.sh
+++ b/ServiceBus-Emulator/Scripts/Common/LaunchEmulator.sh
@@ -7,6 +7,7 @@ COMPOSE_DOWN='n'
 composeFile=$(realpath "$(dirname "$BASH_SOURCE")/../../../Docker-Compose-Template/docker-compose-default.yml")
 SQL_PASSWORD=''
 SQL_WAIT_INTERVAL=''
+EMULATOR_AMQP_PORT=''
 
 # Password regex pattern
 char_allowed='^.{8,128}$'
@@ -77,6 +78,14 @@ do
         fi
     fi
 
+    if [[ $arg == --EMULATOR_AMQP_PORT=* ]]; then
+        EMULATOR_AMQP_PORT="${arg#*=}"
+    fi
+
+    if [[ $arg == --EMULATOR_HTTP_PORT=* ]]; then
+        EMULATOR_HTTP_PORT="${arg#*=}"
+    fi
+
 done
 
 # Skip EULA check if only running docker compose down
@@ -114,6 +123,12 @@ if [[ "$COMPOSE_DOWN" != 'y' && "$COMPOSE_DOWN" != 'Y' ]]; then
         SQL_WAIT_INTERVAL=${SQL_WAIT_INTERVAL:-15}
     fi
 
+    if [ -z "$EMULATOR_AMQP_PORT" ]; then
+        read -p "Enter the emulator AMQP host port for message operations [default: 5672]: " EMULATOR_AMQP_PORT
+        # Set default value if no input is provided
+        EMULATOR_AMQP_PORT=${EMULATOR_AMQP_PORT:-5672}
+    fi
+
     if [ -z "$EMULATOR_HTTP_PORT" ]; then
         read -p "Enter the emulator HTTP port for health-check and Management APIs [default: 5300]: " EMULATOR_HTTP_PORT
         # Set default value if no input is provided
@@ -125,6 +140,7 @@ if [[ "$COMPOSE_DOWN" != 'y' && "$COMPOSE_DOWN" != 'Y' ]]; then
     export ACCEPT_EULA=$ACCEPT_EULA
     export SQL_PASSWORD=$SQL_PASSWORD
     export SQL_WAIT_INTERVAL=$SQL_WAIT_INTERVAL
+    export EMULATOR_AMQP_PORT=$EMULATOR_AMQP_PORT
     export EMULATOR_HTTP_PORT=$EMULATOR_HTTP_PORT
 fi
 

--- a/ServiceBus-Emulator/Scripts/Linux/LaunchEmulator.sh
+++ b/ServiceBus-Emulator/Scripts/Linux/LaunchEmulator.sh
@@ -13,6 +13,8 @@ CONFIG_PATH='../ServiceBus-Emulator/Config/Config.json'
 COMPOSE_DOWN='n'
 composeFile=$(realpath "$(dirname "$BASH_SOURCE")/../../../Docker-Compose-Template/docker-compose-default.yml")
 SQL_PASSWORD=''
+EMULATOR_AMQP_PORT=''
+EMULATOR_HTTP_PORT=''
 
 # Password regex pattern
 char_allowed='^.{8,128}$'
@@ -83,6 +85,14 @@ do
         fi
     fi
 
+    if [[ $arg == --EMULATOR_AMQP_PORT=* ]]; then
+        EMULATOR_AMQP_PORT="${arg#*=}"
+    fi
+
+    if [[ $arg == --EMULATOR_HTTP_PORT=* ]]; then
+        EMULATOR_HTTP_PORT="${arg#*=}"
+    fi
+
 done
 
 # Skip EULA check if only running docker compose down
@@ -122,6 +132,8 @@ fi
 
 # Set Config Path as env variable
 export CONFIG_PATH=$CONFIG_PATH
+if [[ -n "$EMULATOR_AMQP_PORT" ]]; then export EMULATOR_AMQP_PORT=$EMULATOR_AMQP_PORT; fi
+if [[ -n "$EMULATOR_HTTP_PORT" ]]; then export EMULATOR_HTTP_PORT=$EMULATOR_HTTP_PORT; fi
 
 # Run docker compose down
 docker compose -f $composeFile down

--- a/ServiceBus-Emulator/Scripts/Mac/LaunchEmulator.sh
+++ b/ServiceBus-Emulator/Scripts/Mac/LaunchEmulator.sh
@@ -13,6 +13,8 @@ CONFIG_PATH='../ServiceBus-Emulator/Config/Config.json'
 COMPOSE_DOWN='n'
 composeFile=$(realpath "$(dirname "$BASH_SOURCE")/../../../Docker-Compose-Template/docker-compose-default.yml")
 SQL_PASSWORD=''
+EMULATOR_AMQP_PORT=''
+EMULATOR_HTTP_PORT=''
 
 # Password regex pattern
 char_allowed='^.{8,128}$'
@@ -83,6 +85,14 @@ do
         fi
     fi
 
+    if [[ $arg == --EMULATOR_AMQP_PORT=* ]]; then
+        EMULATOR_AMQP_PORT="${arg#*=}"
+    fi
+
+    if [[ $arg == --EMULATOR_HTTP_PORT=* ]]; then
+        EMULATOR_HTTP_PORT="${arg#*=}"
+    fi
+
 done
 
 # Skip EULA check if only running docker compose down
@@ -122,6 +132,8 @@ fi
 
 # Set Config Path as env variable
 export CONFIG_PATH=$CONFIG_PATH
+if [[ -n "$EMULATOR_AMQP_PORT" ]]; then export EMULATOR_AMQP_PORT=$EMULATOR_AMQP_PORT; fi
+if [[ -n "$EMULATOR_HTTP_PORT" ]]; then export EMULATOR_HTTP_PORT=$EMULATOR_HTTP_PORT; fi
 
 # Run docker compose down
 docker compose -f $composeFile down

--- a/ServiceBus-Emulator/Scripts/Windows/LaunchEmulator.ps1
+++ b/ServiceBus-Emulator/Scripts/Windows/LaunchEmulator.ps1
@@ -1,7 +1,9 @@
 param(
   [string]$ACCEPT_EULA='n',
   [string]$CONFIG_PATH='../ServiceBus-Emulator/Config/Config.json',
-  [string]$SQL_PASSWORD=''
+  [string]$SQL_PASSWORD='',
+  [string]$EMULATOR_AMQP_PORT='5672',
+  [string]$EMULATOR_HTTP_PORT='5300'
 )
 
 Write-Warning "As running native .ps1 script required updating your machine's execution policy,
@@ -89,6 +91,12 @@ $env:SQL_PASSWORD = $SQL_PASSWORD
 
 # Set Config Path as env variable
 $env:CONFIG_PATH = $CONFIG_PATH
+
+# Set AMQP host port as env variable
+$env:EMULATOR_AMQP_PORT = $EMULATOR_AMQP_PORT
+
+# Set HTTP management port as env variable
+$env:EMULATOR_HTTP_PORT = $EMULATOR_HTTP_PORT
 
 # Run Docker Compose
 docker compose -f $composeFile down


### PR DESCRIPTION

 ## Summary
 - add configurable AMQP host-port mapping in compose templates via `${EMULATOR_AMQP_PORT:-5672}:5672`
 - add `EMULATOR_AMQP_PORT` support in launch scripts (Windows/Linux/macOS/Common)
 - keep default behavior unchanged when no override is provided (host port remains `5672`)
 - update README with non-default AMQP port usage and connection-string guidance

 ## Problem
 In local mixed-messaging development, teams often run **Azure Service Bus emulator** and **Azure Event Hubs emulator** on the same machine.

 Today, both emulator setups are effectively hardcoded around host AMQP port `5672`:
 - Service Bus emulator defaults to `5672`
 - Event Hubs emulator defaults to `5672`

 Starting both in default mode reproduces the conflict reported in #139:

 `Bind for 0.0.0.0:5672 failed: port is already allocated`

 ## Why this change
 This PR adds installer-supported AMQP host-port configurability so developers can avoid manual compose-file edits when `5672` is already in use.

 ## Compatibility
 - backward compatible by default
 - if `EMULATOR_AMQP_PORT` is not set, behavior remains exactly as before (`5672`)

 ## Validation
 - compose templates render successfully with `docker compose config`
 - launch scripts now pass through `EMULATOR_AMQP_PORT` across platforms
 - downstream local Sentry validation confirmed non-default AMQP host-port bring-up path (`5674 -> 5672`) without regressing default path

 ## Related
 - Closes/addresses #139
